### PR TITLE
Graceful degradation on IE9

### DIFF
--- a/angular-ripple.js
+++ b/angular-ripple.js
@@ -27,7 +27,7 @@
           if (ripple === null) {
             // Create ripple
             ripple = document.createElement('span');
-            ripple.classList.add('angular-ripple');
+            ripple.className += ' angular-ripple';
 
             // Prepend ripple to element
             this.insertBefore(ripple, this.firstChild);
@@ -41,7 +41,7 @@
           }
 
           // Remove animation effect
-          ripple.classList.remove('animate');
+          ripple.className.replace('animate', '');
 
           // get click coordinates by event type
           if (eventType === 'click') {
@@ -66,7 +66,7 @@
           ripple.style.top = (y - offsets.top - size / 2) + 'px';
 
           // Add animation effect
-          ripple.classList.add('animate');
+          ripple.className += ' animate';
 
         });
       }


### PR DESCRIPTION
Supporting IE9 on my project via graceful degredation but angular-ripple was erroring out because of the lack of element.classList support. This should work just as well without causing IE9 to explode. Granted the effect still doesn't work in IE9, this is a cleaner fix than a polyfill.
