### PR TITLE
fix double called event on device which support ontouchend event

### DIFF
--- a/angular-ripple.js
+++ b/angular-ripple.js
@@ -82,7 +82,8 @@
             ripple.className += ' animate';
           }
 
-        element.on('touchend mouseup', func);
+        var eventType = ("ontouchend" in document) ? "touchend" : "mouseup";
+        element.on(eventType, func);
 
         //remove the event listener on scope destroy
         scope.$on('$destroy',function() {


### PR DESCRIPTION
On iPad, when you clicking on button with ripple effect, it has the effect of double ripple, because iPad support touchend and mouseup events.
